### PR TITLE
Make `iter_along_base` always work regardless of base iterator length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file. The format 
 
 Versioning for this project is based on [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.0.14-alpha - 2025-01-26
+
+### Changes
+
+- `ChunkedData::iter_along_base` now returns elements if the base time slice is smaller than the stored data.
+
 ## v0.0.13-alpha - 2025-01-25
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "timeless"
-version = "0.0.13-alpha"
+version = "0.0.14-alpha"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timeless"
-version = "0.0.13-alpha"
+version = "0.0.14-alpha"
 edition = "2021"
 authors = ["Clement Tsang <cjhtsang@uwaterloo.ca>"]
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,17 @@ description = "A crate of utilities for storing in-memory timeseries data."
 readme = "README.md"
 categories = []
 keywords = []
-exclude = [".github", "CHANGELOG.md"]
+exclude = [
+    ".github/",
+    ".idea",
+    ".vscode/",
+    ".gitignore",
+    ".markdownlint.json",
+    "CHANGELOG.md",
+    "clippy.toml",
+    "rustfmt.toml",
+]
+docs = "https://docs.rs/timeless/"
 
 [lib]
 test = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,12 @@
 name = "timeless"
 version = "0.0.14-alpha"
 edition = "2021"
-authors = ["Clement Tsang <cjhtsang@uwaterloo.ca>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ClementTsang/timeless"
 description = "A crate of utilities for storing in-memory timeseries data."
 readme = "README.md"
+documentation = "https://docs.rs/timeless/"
+authors = ["Clement Tsang <cjhtsang@uwaterloo.ca>"]
 categories = []
 keywords = []
 exclude = [
@@ -19,7 +20,6 @@ exclude = [
     "clippy.toml",
     "rustfmt.toml",
 ]
-docs = "https://docs.rs/timeless/"
 
 [lib]
 test = true


### PR DESCRIPTION
It now always returns an iterator, even if the base iterator length is shorter than the `ChunkedData`.